### PR TITLE
idx_jia_isu_uuid_timestamp追加

### DIFF
--- a/sql/0_Schema.sql
+++ b/sql/0_Schema.sql
@@ -35,3 +35,5 @@ CREATE TABLE `isu_association_config` (
   `name` VARCHAR(255) PRIMARY KEY,
   `url` VARCHAR(255) NOT NULL UNIQUE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;
+
+CREATE INDEX idx_jia_isu_uuid_timestamp ON isu_condition (jia_isu_uuid, timestamp);


### PR DESCRIPTION
#1
pt-query-digestで１，2位のクエリどっちもで効くindex

```
MariaDB [isucondition]> explain SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ‘338b9fd8-cde9-4e86-bc55-6049e41f514b’ ORDER BY timestamp DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: isu_condition
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 71225
        Extra: Using where; Using filesort


MariaDB [isucondition]> CREATE INDEX idx_jia_isu_uuid_timestamp ON isu_condition (jia_isu_uuid, timestamp);
Query OK, 0 rows affected (0.318 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [isucondition]> explain SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ‘338b9fd8-cde9-4e86-bc55-6049e41f514b’ ORDER BY timestamp DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: isu_condition
         type: ref
possible_keys: idx_jia_isu_uuid_timestamp
          key: idx_jia_isu_uuid_timestamp
      key_len: 144
          ref: const
         rows: 1186
        Extra: Using where
1 row in set (0.003 sec)
```

```
MariaDB [isucondition]> explain SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ’a085ec80-f46a-4914-b400-5096346670d9’AND `timestamp` < ’2021-08-30 03:58:30’ORDER BY `timestamp` DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: isu_condition
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 71225
        Extra: Using where; Using filesort
1 row in set (0.004 sec)

MariaDB [isucondition]> CREATE INDEX idx_jia_isu_uuid_timestamp ON isu_condition (jia_isu_uuid, timestamp);
Query OK, 0 rows affected (0.294 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [isucondition]> explain SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ’a085ec80-f46a-4914-b400-5096346670d9’AND `timestamp` < ’2021-08-30 03:58:30’ORDER BY `timestamp` DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: isu_condition
         type: range
possible_keys: idx_jia_isu_uuid_timestamp
          key: idx_jia_isu_uuid_timestamp
      key_len: 149
          ref: NULL
         rows: 1402
        Extra: Using where
1 row in set (0.002 sec)
```