### PR TITLE
iconを静的にしたよ

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -34,7 +34,7 @@ const (
 	frontendContentsPath        = "../public"
 	jiaJWTSigningKeyPath        = "../ec256-public.pem"
 	defaultIconFilePath         = "../NoImage.jpg"
-	iconImagePath               = "../public/images/api/isu"
+	iconImagePath               = "../public/tmp"
 	defaultJIAServiceURL        = "http://localhost:5000"
 	mysqlErrNumDuplicateEntry   = 1062
 	conditionLevelInfo          = "info"
@@ -217,7 +217,7 @@ func init() {
 
 func main() {
 	e := echo.New()
-	e.Debug = true
+	e.Debug = false
 	e.Logger.SetLevel(log.DEBUG)
 
 	e.Use(middleware.Logger())

--- a/go/main.go
+++ b/go/main.go
@@ -399,6 +399,11 @@ func postInitialize(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
+	_, err = db.Exec("UPDATE isu set image = ''")
+	if err != nil {
+		c.Logger().Error(err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
 	c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 	c.Response().WriteHeader(http.StatusOK)
 	return c.JSON(http.StatusOK, InitializeResponse{

--- a/go/main.go
+++ b/go/main.go
@@ -858,7 +858,9 @@ func generateIsuGraphResponse(tx *sqlx.Tx, jiaIsuUUID string, graphDate time.Tim
 	var startTimeInThisHour time.Time
 	var condition IsuCondition
 
-	rows, err := tx.Queryx("SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ? ORDER BY `timestamp` ASC", jiaIsuUUID)
+	rows, err := tx.Queryx("SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ? "+
+		"`timestamp` BETWEEN ? AND ? "+
+		"ORDER BY `timestamp` ASC", jiaIsuUUID, graphDate.Format("2006-01-02")+" 00:00:00", graphDate.Format("2006-01-02")+" 23:59:59")
 	if err != nil {
 		return nil, fmt.Errorf("db error: %v", err)
 	}

--- a/go/main.go
+++ b/go/main.go
@@ -398,7 +398,7 @@ func postInitialize(c echo.Context) error {
 		c.Logger().Error(err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	
+
 	c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 	c.Response().WriteHeader(http.StatusOK)
 	return c.JSON(http.StatusOK, InitializeResponse{
@@ -784,7 +784,7 @@ func getIsuIcon(c echo.Context) error {
 	}
 
 	var filename string
-	if useDefaultImage {
+	if !useDefaultImage {
 		filename = fmt.Sprintf("/icon/%s.jpg", jiaIsuUUID)
 	} else {
 		filename = iconImagePath + "/icon/NoImage.jpg"

--- a/go/main.go
+++ b/go/main.go
@@ -217,7 +217,7 @@ func init() {
 
 func main() {
 	e := echo.New()
-	e.Debug = false
+	e.Debug = true
 	e.Logger.SetLevel(log.DEBUG)
 
 	e.Use(middleware.Logger())

--- a/go/main.go
+++ b/go/main.go
@@ -858,9 +858,10 @@ func generateIsuGraphResponse(tx *sqlx.Tx, jiaIsuUUID string, graphDate time.Tim
 	var startTimeInThisHour time.Time
 	var condition IsuCondition
 
-	rows, err := tx.Queryx("SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ? "+
-		"`timestamp` BETWEEN ? AND ? "+
-		"ORDER BY `timestamp` ASC", jiaIsuUUID, graphDate.Format("2006-01-02")+" 00:00:00", graphDate.Format("2006-01-02")+" 23:59:59")
+	rows, err := tx.Queryx("SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ? AND `timestamp` BETWEEN ? AND ? ORDER BY `timestamp` ASC",
+		jiaIsuUUID,
+		graphDate.Format("2006-01-02")+" 00:00:00",
+		graphDate.Format("2006-01-02")+" 23:59:59")
 	if err != nil {
 		return nil, fmt.Errorf("db error: %v", err)
 	}

--- a/go/main.go
+++ b/go/main.go
@@ -787,7 +787,7 @@ func getIsuIcon(c echo.Context) error {
 	if !useDefaultImage {
 		filename = fmt.Sprintf("/icon/%s.jpg", jiaIsuUUID)
 	} else {
-		filename = iconImagePath + "/icon/NoImage.jpg"
+		filename = "/icon/NoImage.jpg"
 	}
 	c.Response().Header().Set("X-Accel-Redirect", filename)
 	return c.File(filename)

--- a/go/main.go
+++ b/go/main.go
@@ -777,7 +777,7 @@ func getIsuIcon(c echo.Context) error {
 	}
 
 	var filename string
-	if len(image) >= 0 {
+	if len(image) > 0 {
 		filename = fmt.Sprintf("/icon/%s.jpg", jiaIsuUUID)
 	} else {
 		filename = iconImagePath + "/icon/NoImage.jpg"


### PR DESCRIPTION
```
16:07:05.808125 score: 13195(13198 - 3) : pass
16:07:05.808157 deduction: 0 / timeout: 31
16:07:05.808190 <=== sendResult finish
```

```
Top 20 Sort By Total
Count    Total    Mean  Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max    2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
 2870  211.466  0.0737  0.1387  0.000  0.019  0.246  0.310  0.690  1.002   2273    0  597    0    12690372          0       4421       7363  GET /api/condition/[a-z0-9-]+
65428  143.378  0.0022  0.0041  0.000  0.001  0.005  0.007  0.014  0.106  65374    0   54    0         112          0          0         14  POST /api/condition/[a-z0-9-]+
  145  136.685  0.9427  0.1932  0.134  1.000  1.001  1.004  1.008  1.012     13    0  132    0       64290          0        443       6815  GET /api/trend HTTP/2.0
 2900  105.944  0.0365  0.1029  0.000  0.007  0.056  0.234  0.510  1.004   1971    0  929    0    22803065          0       7863     135259  GET /api/isu/[a-z0-9-]+
  742   46.793  0.0631  0.1007  0.000  0.022  0.232  0.250  0.456  0.644    657    0   85    0     1762501          0       2375       4643  GET /api/isu HTTP/2.0
 1055    6.737  0.0064  0.0331  0.000  0.004  0.009  0.013  0.025  1.001    374    0  681    0        7820          0          7         19  POST /api/auth HTTP/2.0
   48    3.789  0.0789  0.0503  0.000  0.070  0.105  0.129  0.293  0.293     44    0    4    0        6118         15        127        151  POST /api/isu HTTP/2.0
  314    1.615  0.0051  0.0305  0.000  0.001  0.006  0.010  0.044  0.446    119    0  195    0        8420         21         26         42  GET /api/user/me HTTP/2.0
  199    0.654  0.0033  0.0035  0.000  0.002  0.007  0.011  0.017  0.021    112    0   87    0        1827          0          9         21  POST /api/signout HTTP/2.0
    1    0.497  0.4970  0.0000  0.497  0.497  0.497  0.497  0.497  0.497      1    0    0    0          23         23         23         23  POST /initialize HTTP/2.0
  143    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    143    0    0    0     3813381      26667      26667      26667  GET /assets/index.23dac98b.js HTTP/2.0
  143    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    143    0    0    0      469755       3285       3285       3285  GET /assets/logo_white.svg HTTP/2.0
  143    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    143    0    0    0       84656        592        592        592  GET /assets/favicon.d0f5f504.svg HTTP/2.0
  143    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    143    0    0    0     2726438      19066      19066      19066  GET /assets/index.144d8ca8.css HTTP/2.0
  142    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    142    0    0    0      466896       3288       3288       3288  GET /assets/logo_orange.svg HTTP/2.0
  263    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000    263    0    0    0      138864        528        528        528  GET / HTTP/2.0
    9    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000      9    0    0    0        4752        528        528        528  GET /isu/[a-z0-9-]+
    5    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000      5    0    0    0        2640        528        528        528  GET /isu/[a-z0-9-]+/graph
    4    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000      4    0    0    0        2112        528        528        528  GET /isu/[a-z0-9-]+/condition
    1    0.000  0.0000  0.0000  0.000  0.000  0.000  0.000  0.000  0.000      1    0    0    0         528        528        528        528  GET /register HTTP/2.0
```